### PR TITLE
Fix systemd timer file by adding "Requires" field

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -419,6 +419,7 @@ def timer_file():
     return f"""\
 [Unit]
 Description=Check multiple websites for new flat exposes
+Requires=flatcrawler.service
 
 [Timer]
 OnUnitActiveSec={CHECK_INTERVAL}s


### PR DESCRIPTION
Without the "Requires" field in the "Unit" section of the timer file starting
flatcrawler automatically does not work.
The command that generates the timer file now also includes this field.

This fixes #15 