### PR TITLE
Fix key error in "load_config" when loading "site-blocklist"

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -93,7 +93,7 @@ def load_config(file="config.yaml"):
             search_config["gewobag_districts"] or []
         )
         search_config["no_1st_floor"] = (search_config["floor_min"] or 0) > 1
-        search_config["site-blocklist"] = data["site-blocklist"] or []
+        search_config["site-blocklist"] = search_config["site-blocklist"] or []
         mail_config = defaultdict(lambda: None, data["mail"] or {})
     return search_config, sendmail.MailConfig(mail_config)
 


### PR DESCRIPTION
The site-blocklist is part of the "search" section of config.yaml. It was accessed on
the wrong dictionary.

This pull request fixes a tiny error that was introduced by commit ad3b74c3ee721e3f5080d5a55c733d5567f339ff.